### PR TITLE
chore: add Renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["local>Xelians/renovate-config"],
+  "enabledManagers": ["maven", "github-actions"]
+}


### PR DESCRIPTION
Adds `renovate.json` with the correct `enabledManagers` based on dry-run detection.

Part of Renovate full rollout — DEVOPS-4242.