### PR TITLE
chore: update SCM url to main branch (DEVOPS-4235)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
     <scm>
         <connection>scm:git:git://github.com/Xelians/datahub-studio.git</connection>
         <developerConnection>scm:git:ssh://github.com:Xelians/datahub-studio.git</developerConnection>
-        <url>https://github.com/Xelians/datahub-studio/tree/master</url>
+        <url>https://github.com/Xelians/datahub-studio/tree/main</url>
     </scm>
 
     <properties>


### PR DESCRIPTION
## What
Update the `<scm><url>` in `pom.xml` from `/tree/master` to `/tree/main`.

## Why
Part of the org-wide `master` → `main` branch migration ([DEVOPS-4235](https://xelians.atlassian.net/browse/DEVOPS-4235)). Once `master` is deleted, the `/tree/master` SCM URL would 404. No functional impact (the workflow is `workflow_dispatch` and consumers depend on the Maven artifact by version, not the git branch) — this just keeps the project metadata link valid.

## Change
```diff
-        <url>https://github.com/Xelians/datahub-studio/tree/master</url>
+        <url>https://github.com/Xelians/datahub-studio/tree/main</url>
```

[DEVOPS-4235]: https://xelians.atlassian.net/browse/DEVOPS-4235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ